### PR TITLE
Make infinite scrolling activity indicator visible

### DIFF
--- a/ICSPullToRefresh/ICSInfiniteScrolling.swift
+++ b/ICSPullToRefresh/ICSInfiniteScrolling.swift
@@ -155,6 +155,12 @@ public class InfiniteScrollingView: UIView {
             if (scrollViewContentHeight < self.scrollView!.bounds.height) {
                 scrollOffsetThreshold = 40 - self.scrollView!.contentInset.top
             }
+
+            activityIndicator.hidesWhenStopped = !(
+                scrollView!.dragging &&
+                scrollViewContentHeight > self.scrollView!.bounds.height
+            )
+
             if !scrollView!.dragging && state == .Triggered {
                 state = .Loading
             } else if contentOffset!.y > scrollOffsetThreshold && state == .Stopped && scrollView!.dragging {


### PR DESCRIPTION
I'm not sure why `hidesWhenStopped` was set to `true` previously. For pull-to-refresh view it's set to `false` and it works perfectly. The thing is that it's not obvious for users that infinite scrolling is enabled without an indicator present, so this change brings consistency and UX improvement. Please correct me if this wrong thing to do. Thanks!
