### PR TITLE
Prevent a state loop, that happen if Stopped state is in transition

### DIFF
--- a/ICSPullToRefresh/ICSInfiniteScrolling.swift
+++ b/ICSPullToRefresh/ICSInfiniteScrolling.swift
@@ -101,8 +101,6 @@ public class InfiniteScrollingView: UIView {
             if state != newValue {
                 self.setNeedsLayout()
                 switch newValue{
-                case .Stopped:
-                    resetScrollViewContentInset()
                 case .Loading:
                     setScrollViewContentInsetForInfiniteScrolling()
                     if state == .Triggered {
@@ -111,6 +109,16 @@ public class InfiniteScrollingView: UIView {
                 default:
                     break
                 }
+            }
+        }
+
+        didSet {
+            switch state {
+            case .Stopped:
+                resetScrollViewContentInset()
+
+            default:
+                break
             }
         }
     }


### PR DESCRIPTION
How to reproduce:
1. Invoke stopAnimating() inside infiniteScrollingView handler without any delay
2. Start dragging up to show infiniteScrollingView

What's happening on the `willSet` closure:

While the state is still "Triggered" but not yet stopped, modifying the
`contentInset` will cause an infinite loop.

It never changes to Stopped, because, while scrolling happens, and
state is triggered, it'll set it back to Loading, and it will invoke
the actionHandler() once again, and it goes back to the willSet case of
Stopped -> scrollViewDidScroll ->  Loading -> Triggered -> ...

Moving the `resetScrollViewContentInset` to `didSet` closure, will only set
content inset, once the state has settled to Stopped
