### PR TITLE
Updated code to make it more Swifty and few api changes.

### DIFF
--- a/ICSPullToRefresh.xcodeproj/project.pbxproj
+++ b/ICSPullToRefresh.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = TouchingAPP;
 				TargetAttributes = {
 					9B2781461AB592FA00769BE5 = {
@@ -218,8 +218,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				9B2781461AB592FA00769BE5 /* ICSPullToRefresh */,
 				9B2781661AB5933E00769BE5 /* ICSPullToRefreshDemo */,
+				9B2781461AB592FA00769BE5 /* ICSPullToRefresh */,
 			);
 		};
 /* End PBXProject section */
@@ -315,6 +315,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -394,6 +395,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -412,6 +414,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -429,6 +432,7 @@
 				INFOPLIST_FILE = ICSPullToRefreshDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -441,6 +445,7 @@
 				INFOPLIST_FILE = ICSPullToRefreshDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/ICSPullToRefresh.xcodeproj/xcshareddata/xcschemes/ICSPullToRefresh.xcscheme
+++ b/ICSPullToRefresh.xcodeproj/xcshareddata/xcschemes/ICSPullToRefresh.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:ICSPullToRefresh.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/ICSPullToRefresh/ICSPullToRefresh.swift
+++ b/ICSPullToRefresh/ICSPullToRefresh.swift
@@ -11,208 +11,227 @@ import UIKit
 private var pullToRefreshViewKey: Void?
 private let observeKeyContentOffset = "contentOffset"
 private let observeKeyFrame = "frame"
-
 private let ICSPullToRefreshViewHeight: CGFloat = 60
+public typealias ActionHandler = () -> Void
 
-public typealias ActionHandler = () -> ()
-
-public extension UIScrollView{
-    
+public extension UIScrollView {
     public var pullToRefreshView: PullToRefreshView? {
         get {
             return objc_getAssociatedObject(self, &pullToRefreshViewKey) as? PullToRefreshView
         }
-        set(newValue) {
-            self.willChangeValueForKey("ICSPullToRefreshView")
+        set {
+            willChangeValueForKey("ICSPullToRefreshView")
             objc_setAssociatedObject(self, &pullToRefreshViewKey, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
-            self.didChangeValueForKey("ICSPullToRefreshView")
+            didChangeValueForKey("ICSPullToRefreshView")
         }
     }
-    
-    public var showsPullToRefresh: Bool {
-        return pullToRefreshView != nil ? pullToRefreshView!.hidden : false
-    }
-    
-    public func addPullToRefreshHandler(actionHandler: ActionHandler){
+
+    public func addPullToRefreshHandler(actionHandler: ActionHandler) {
         if pullToRefreshView == nil {
-            pullToRefreshView = PullToRefreshView(frame: CGRect(x: CGFloat(0), y: -ICSPullToRefreshViewHeight, width: self.bounds.width, height: ICSPullToRefreshViewHeight))
+            pullToRefreshView = PullToRefreshView(frame: CGRect(x: 0, y: -ICSPullToRefreshViewHeight, width: bounds.width, height: ICSPullToRefreshViewHeight))
             addSubview(pullToRefreshView!)
             pullToRefreshView?.autoresizingMask = .FlexibleWidth
             pullToRefreshView?.scrollViewOriginContentTopInset = contentInset.top
         }
         pullToRefreshView?.actionHandler = actionHandler
-        setShowsPullToRefresh(true)
+        showsPullToRefresh = true
     }
-    
+
     public func triggerPullToRefresh() {
         pullToRefreshView?.state = .Triggered
         pullToRefreshView?.startAnimating()
     }
-    
-    public func setShowsPullToRefresh(showsPullToRefresh: Bool) {
-        if pullToRefreshView == nil {
-            return
-        }
-        pullToRefreshView!.hidden = !showsPullToRefresh
-        if showsPullToRefresh{
-            addPullToRefreshObservers()
-        }else{
-            removePullToRefreshObservers()
-        }
-    }
-    
-    func addPullToRefreshObservers() {
-        if pullToRefreshView?.isObserving != nil && !pullToRefreshView!.isObserving{
-            addObserver(pullToRefreshView!, forKeyPath: observeKeyContentOffset, options:.New, context: nil)
-            addObserver(pullToRefreshView!, forKeyPath: observeKeyFrame, options:.New, context: nil)
-            pullToRefreshView!.isObserving = true
-        }
-    }
-    
-    func removePullToRefreshObservers() {
-        if pullToRefreshView?.isObserving != nil && pullToRefreshView!.isObserving{
-            removeObserver(pullToRefreshView!, forKeyPath: observeKeyContentOffset)
-            removeObserver(pullToRefreshView!, forKeyPath: observeKeyFrame)
-            pullToRefreshView!.isObserving = false
+
+    public var showsPullToRefresh: Bool {
+        get { return pullToRefreshView?.hidden ?? false }
+        set {
+            guard let pullToRefreshView = pullToRefreshView else { return }
+
+            pullToRefreshView.hidden = !newValue
+
+            if newValue {
+                addPullToRefreshObservers()
+            } else {
+                removePullToRefreshObservers()
+            }
         }
     }
 
-    
+    private func addPullToRefreshObservers() {
+        guard let pullToRefreshView = pullToRefreshView where !pullToRefreshView.isObserving else { return }
+
+        addObserver(pullToRefreshView, forKeyPath: observeKeyContentOffset, options: .New, context: nil)
+        addObserver(pullToRefreshView, forKeyPath: observeKeyFrame, options: .New, context: nil)
+        pullToRefreshView.isObserving = true
+    }
+
+    private func removePullToRefreshObservers() {
+        guard let pullToRefreshView = pullToRefreshView where pullToRefreshView.isObserving else { return }
+
+        removeObserver(pullToRefreshView, forKeyPath: observeKeyContentOffset)
+        removeObserver(pullToRefreshView, forKeyPath: observeKeyFrame)
+        pullToRefreshView.isObserving = false
+    }
 }
 
 public class PullToRefreshView: UIView {
+    private lazy var defaultView = UIView()
+    private var triggeredByUser = false
     public var actionHandler: ActionHandler?
-    public var isObserving: Bool = false
-    var triggeredByUser: Bool = false
-    
+    public var isObserving = false
     public var scrollView: UIScrollView? {
-        return self.superview as? UIScrollView
+        return superview as? UIScrollView
     }
-    
+
+    public lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .Gray)
+        activityIndicator.hidesWhenStopped = false
+        return activityIndicator
+    }()
+
     public var scrollViewOriginContentTopInset: CGFloat = 0
-    
+
     public enum State {
         case Stopped
         case Triggered
         case Loading
         case All
     }
-    
+
     public var state: State = .Stopped {
         willSet {
-            if state != newValue {
-                self.setNeedsLayout()
-                switch newValue{
-                case .Loading:
-                    setScrollViewContentInsetForLoading()
-                    if state == .Triggered {
-                        actionHandler?()
-                    }
-                default:
-                    break
+            guard state != newValue else { return }
+            setNeedsLayout()
+
+            if case .Loading = newValue {
+                setScrollViewContentInsetForLoading()
+                if state == .Triggered {
+                    actionHandler?()
                 }
             }
         }
         didSet {
-            switch state {
-            case .Stopped:
+            if case .Stopped = state {
                 resetScrollViewContentInset()
-                
-            default:
-                break
             }
         }
     }
-    
-    
+
+    // MARK: Init Methods
+
+    public convenience init() {
+        self.init(frame: .zero)
+    }
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        initViews()
+        commonInit()
     }
 
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        initViews()
+        commonInit()
     }
-    
-    public func startAnimating() {
-        if scrollView == nil {
-            return
+
+    private func commonInit() {
+        addSubview(defaultView)
+        defaultView.addSubview(activityIndicator)
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        defaultView.frame = bounds
+        activityIndicator.center = defaultView.center
+
+        switch state {
+            case .Stopped:
+                activityIndicator.stopAnimating()
+            case .Loading:
+                activityIndicator.startAnimating()
+            default:
+                break
         }
+    }
+
+    public override func willMoveToSuperview(newSuperview: UIView?) {
+        guard newSuperview == nil else { return }
+        scrollView?.removePullToRefreshObservers()
+    }
+
+    public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        if keyPath == observeKeyContentOffset {
+            scrollViewDidScroll(change?[NSKeyValueChangeNewKey]?.CGPointValue)
+        } else if keyPath == observeKeyFrame {
+            setNeedsLayout()
+        }
+    }
+
+    public func startAnimating() {
+        guard let scrollView = scrollView else { return }
 
         animate {
-            self.scrollView?.setContentOffset(CGPoint(
-                x: self.scrollView!.contentOffset.x,
-                y: -(self.scrollView!.contentInset.top + self.bounds.height)
-            ), animated: false)
+            scrollView.contentOffset.y = -(scrollView.contentInset.top + self.bounds.height)
         }
 
         triggeredByUser = true
         state = .Loading
     }
-    
+
     public func stopAnimating() {
         state = .Stopped
-        if triggeredByUser {
-            animate {
-                self.scrollView?.setContentOffset(CGPoint(
-                    x: self.scrollView!.contentOffset.x,
-                    y: -self.scrollView!.contentInset.top
-                ), animated: false)
-            }
+
+        guard let scrollView = scrollView where triggeredByUser else { return }
+
+        animate {
+            scrollView.setContentOffset(CGPoint(
+                x: scrollView.contentOffset.x,
+                y: -scrollView.contentInset.top
+            ), animated: false)
         }
     }
 
-    public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
-        if keyPath == observeKeyContentOffset {
-            srollViewDidScroll(change?[NSKeyValueChangeNewKey]?.CGPointValue)
-        } else if keyPath == observeKeyFrame {
-            setNeedsLayout()
-        }
-    }
-    
-    private func srollViewDidScroll(contentOffset: CGPoint?) {
-        if scrollView == nil || contentOffset == nil{
+    private func scrollViewDidScroll(contentOffset: CGPoint?) {
+        guard let contentOffset = contentOffset, scrollView = scrollView where state != .Loading else {
             return
         }
-        if state != .Loading {
-            let scrollOffsetThreshold = frame.origin.y - scrollViewOriginContentTopInset
-            if !scrollView!.dragging && state == .Triggered {
-                state = .Loading
-            } else if contentOffset!.y < scrollOffsetThreshold && scrollView!.dragging && state == .Stopped {
-                state = .Triggered
-            } else if contentOffset!.y >= scrollOffsetThreshold && state != .Stopped {
-                state == .Stopped
-            }
+
+        let scrollOffsetThreshold = frame.origin.y - scrollViewOriginContentTopInset
+
+        if !scrollView.dragging && state == .Triggered {
+            state = .Loading
+        } else if contentOffset.y < scrollOffsetThreshold && scrollView.dragging && state == .Stopped {
+            state = .Triggered
+        } else if contentOffset.y >= scrollOffsetThreshold && state != .Stopped {
+            state == .Stopped
         }
     }
-    
+
     private func setScrollViewContentInset(contentInset: UIEdgeInsets) {
         animate {
             self.scrollView?.contentInset = contentInset
         }
     }
-    
+
     private func resetScrollViewContentInset() {
-        if scrollView == nil {
-            return
-        }
-        var currentInset = scrollView!.contentInset
+        guard let scrollView = scrollView else { return }
+
+        var currentInset = scrollView.contentInset
         currentInset.top = scrollViewOriginContentTopInset
         setScrollViewContentInset(currentInset)
     }
-    
+
     private func setScrollViewContentInsetForLoading() {
-        if scrollView == nil {
-            return
-        }
-        let offset = max(scrollView!.contentOffset.y * -1, 0)
-        var currentInset = scrollView!.contentInset
+        guard let scrollView = scrollView else { return }
+
+        let offset = max(scrollView.contentOffset.y * -1, 0)
+        var currentInset = scrollView.contentInset
         currentInset.top = min(offset, scrollViewOriginContentTopInset + bounds.height)
         setScrollViewContentInset(currentInset)
     }
 
-    private func animate(animations: () -> ()) {
+    // MARK: Helpers
+
+    private func animate(animations: () -> Void) {
         UIView.animateWithDuration(0.3,
             delay: 0,
             options: [.AllowUserInteraction, .BeginFromCurrentState],
@@ -221,53 +240,4 @@ public class PullToRefreshView: UIView {
             self.setNeedsLayout()
         }
     }
-
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        defaultView.frame = self.bounds
-        activityIndicator.center = defaultView.center
-        switch state {
-        case .Stopped:
-            activityIndicator.stopAnimating()
-        case .Loading:
-            activityIndicator.startAnimating()
-        default:
-            break
-        }
-    }
-    
-    public override func willMoveToSuperview(newSuperview: UIView?) {
-        if superview != nil && newSuperview == nil {
-            if scrollView?.showsPullToRefresh != nil && scrollView!.showsPullToRefresh{
-                scrollView?.removePullToRefreshObservers()
-            }
-        }
-    }
-    
-    // MARK: Basic Views
-    
-    func initViews() {
-        addSubview(defaultView)
-        defaultView.addSubview(activityIndicator)
-    }
-    
-    lazy var defaultView: UIView = {
-        let view = UIView()
-        return view
-    }()
-    
-    lazy var activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.Gray)
-        activityIndicator.hidesWhenStopped = false
-        return activityIndicator
-    }()
-
-    public func setActivityIndicatorColor(color: UIColor) {
-        activityIndicator.color = color
-    }
-
-    public func setActivityIndicatorStyle(style: UIActivityIndicatorViewStyle) {
-        activityIndicator.activityIndicatorViewStyle = style
-    }
-    
 }

--- a/ICSPullToRefresh/Info.plist
+++ b/ICSPullToRefresh/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ICSPullToRefreshDemo/Info.plist
+++ b/ICSPullToRefreshDemo/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.touchingapp.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
#### Swifty changes:
- Use of `guard` statements for early exits
- Removed bunch of force optional unwrapping with `guards` and `if-let` patterns
- Fixed a private function name typo: `srollViewDidScroll` => `scrollViewDidScroll`
#### API changes:
1. `public var showsPullToRefresh: Bool { get }` had only getter and for setter it exposed `setShowsPullToRefresh:showsPullToRefresh:` and now setter is included to unify the api with get/set => `public var showsPullToRefresh: Bool { get set }`
2. `PullToRefreshView.setActivityIndicatorColor:` and `PullToRefreshView:setActivityIndicatorStyle:` are removed. Instead the `PullToRefreshView.activityIndicator` property is made public to customize any/all the properties of `UIActivityIndicatorView`

Feel free to pick only subset of changes or toss them all.
